### PR TITLE
fix: Use full registry URLs to support OpenTofu

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -29,6 +29,10 @@ jobs:
         run: |
           sudo sh -c 'curl -sL https://github.com/terraform-docs/terraform-docs/releases/download/v0.17.0/terraform-docs-v0.17.0-linux-amd64.tar.gz | tar xzf - -C /usr/local/bin'
           sudo chmod 0755 /usr/local/bin/terraform-docs
+      - name: Install terragrunt
+        run: |
+          sudo curl -sLo /usr/local/bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v0.58.1/terragrunt_linux_amd64
+          sudo chmod 0755 /usr/local/bin/terragrunt
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'

--- a/_env/base-google-apis-dns-zones.hcl
+++ b/_env/base-google-apis-dns-zones.hcl
@@ -12,7 +12,7 @@ dependency "vpc" {
 }
 
 terraform {
-  source = "tfr:///memes/restricted-apis-dns/google?version=1.3.0"
+  source = "tfr://registry.terraform.io/memes/restricted-apis-dns/google?version=1.3.0"
 }
 
 inputs = {

--- a/_env/base-vpc-peering.hcl
+++ b/_env/base-vpc-peering.hcl
@@ -20,7 +20,7 @@ dependency "spoke" {
 }
 
 terraform {
-  source = "tfr:///terraform-google-modules/network/google//modules/network-peering?version=8.1.0"
+  source = "tfr://registry.terraform.io/terraform-google-modules/network/google//modules/network-peering?version=9.1.0"
 }
 
 inputs = {

--- a/_env/base-vpc.hcl
+++ b/_env/base-vpc.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "tfr:///memes/multi-region-private-network/google?version=2.1.0"
+  source = "tfr://registry.terraform.io/memes/multi-region-private-network/google?version=2.1.0"
 }
 
 inputs = {

--- a/_env/restricted-google-apis-dns-zones.hcl
+++ b/_env/restricted-google-apis-dns-zones.hcl
@@ -12,7 +12,7 @@ dependency "vpc" {
 }
 
 terraform {
-  source = "tfr:///memes/restricted-apis-dns/google?version=1.3.0"
+  source = "tfr://registry.terraform.io/memes/restricted-apis-dns/google?version=1.3.0"
 }
 
 inputs = {

--- a/_env/restricted-vpc-peering.hcl
+++ b/_env/restricted-vpc-peering.hcl
@@ -20,7 +20,7 @@ dependency "spoke" {
 }
 
 terraform {
-  source = "tfr:///terraform-google-modules/network/google//modules/network-peering?version=8.1.0"
+  source = "tfr://registry.terraform.io/terraform-google-modules/network/google//modules/network-peering?version=9.1.0"
 }
 
 inputs = {

--- a/_env/restricted-vpc.hcl
+++ b/_env/restricted-vpc.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = "tfr:///memes/multi-region-private-network/google?version=2.1.0"
+  source = "tfr://registry.terraform.io/memes/multi-region-private-network/google?version=2.1.0"
 }
 
 inputs = {


### PR DESCRIPTION
Sources that reference a registry (`tfr://`) have been modified to use the full registry URL so that OpenTofu works with the repo. Tested with OpenTofu v1.7.0 and Terragrunt v0.58.1.