### PR TITLE
feat: Refactor for relocation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ Gemfile.lock
 .terraform
 .terraform.lock.hcl
 .terragrunt-cache
+
+# Ignore root config and generated files
+/terragrunt.hcl
+_backend.tf
+_providers.tf

--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -1,7 +1,10 @@
 {
     "version": "0.2",
     "language": "en",
-    "words": [],
+    "words": [
+        "talismanrc",
+        "terragrunt"
+    ],
     "flagWords": [
         "hte"
     ]

--- a/_components/base-vpc-peering.hcl
+++ b/_components/base-vpc-peering.hcl
@@ -1,12 +1,19 @@
+# Peering takes some time; allow terragrunt to retry when there is an error.
+retryable_errors = concat(get_default_retryable_errors(), [
+  "There is a peering operation in progress on the local or peer network\\. Try again later\\.",
+])
+retry_max_attempts       = 5
+retry_sleep_interval_sec = 30
+
 dependencies {
   paths = [
-    "${get_repo_root()}/shared/base/vpc/",
+    "${find_in_parent_folders("shared")}/base/vpc/",
     "../vpc/",
   ]
 }
 
 dependency "hub" {
-  config_path = "${get_repo_root()}/shared/base/vpc/"
+  config_path = "${find_in_parent_folders("shared")}/base/vpc/"
   mock_outputs = {
     self_link = "https://www.googleapis.com/compute/v1/projects/mock-project/global/networks/mock-base-hub"
   }

--- a/_components/default-dns-policy.hcl
+++ b/_components/default-dns-policy.hcl
@@ -20,7 +20,7 @@ dependency "restricted_vpc" {
 }
 
 terraform {
-  source = "${get_repo_root()}/modules/vpc-dns-policy/"
+  source = "${find_in_parent_folders("modules")}/vpc-dns-policy/"
 }
 
 inputs = {

--- a/_components/restricted-vpc-peering.hcl
+++ b/_components/restricted-vpc-peering.hcl
@@ -1,12 +1,19 @@
+# Peering takes some time; allow terragrunt to retry when there is an error.
+retryable_errors = concat(get_default_retryable_errors(), [
+  "There is a peering operation in progress on the local or peer network\\. Try again later\\.",
+])
+retry_max_attempts       = 5
+retry_sleep_interval_sec = 30
+
 dependencies {
   paths = [
-    "${get_repo_root()}/shared/restricted/vpc/",
+    "${find_in_parent_folders("shared")}/restricted/vpc/",
     "../vpc/",
   ]
 }
 
 dependency "hub" {
-  config_path = "${get_repo_root()}/shared/restricted/vpc/"
+  config_path = "${find_in_parent_folders("shared")}/restricted/vpc/"
   mock_outputs = {
     self_link = "https://www.googleapis.com/compute/v1/projects/mock-project/global/networks/mock-restricted-hub"
   }

--- a/development/base/google-apis-dns-zones/terragrunt.hcl
+++ b/development/base/google-apis-dns-zones/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 include "env" {
-  path = "${get_repo_root()}/_components/base-google-apis-dns-zones.hcl"
+  path = "${find_in_parent_folders("_components")}/base-google-apis-dns-zones.hcl"
 }
 
 remote_state = include.root.remote_state

--- a/development/base/vpc-peering/terragrunt.hcl
+++ b/development/base/vpc-peering/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 include "env" {
-  path = "${get_repo_root()}/_components/base-vpc-peering.hcl"
+  path = "${find_in_parent_folders("_components")}/base-vpc-peering.hcl"
 }
 
 remote_state = include.root.remote_state

--- a/development/base/vpc/terragrunt.hcl
+++ b/development/base/vpc/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 include "base" {
-  path = "${get_repo_root()}/_components/base-vpc.hcl"
+  path = "${find_in_parent_folders("_components")}/base-vpc.hcl"
 }
 
 remote_state = include.root.remote_state

--- a/development/default-dns-policy/terragrunt.hcl
+++ b/development/default-dns-policy/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 include "env" {
-  path = "${get_repo_root()}/_components/default-dns-policy.hcl"
+  path = "${find_in_parent_folders("_components")}/default-dns-policy.hcl"
 }
 
 remote_state = include.root.remote_state

--- a/development/restricted/google-apis-dns-zones/terragrunt.hcl
+++ b/development/restricted/google-apis-dns-zones/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 include "env" {
-  path = "${get_repo_root()}/_components/restricted-google-apis-dns-zones.hcl"
+  path = "${find_in_parent_folders("_components")}/restricted-google-apis-dns-zones.hcl"
 }
 
 remote_state = include.root.remote_state

--- a/development/restricted/vpc-peering/terragrunt.hcl
+++ b/development/restricted/vpc-peering/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 include "env" {
-  path = "${get_repo_root()}/_components/restricted-vpc-peering.hcl"
+  path = "${find_in_parent_folders("_components")}/restricted-vpc-peering.hcl"
 }
 
 remote_state = include.root.remote_state

--- a/development/restricted/vpc/terragrunt.hcl
+++ b/development/restricted/vpc/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 include "env" {
-  path = "${get_repo_root()}/_components/restricted-vpc.hcl"
+  path = "${find_in_parent_folders("_components")}/restricted-vpc.hcl"
 }
 
 remote_state = include.root.remote_state

--- a/dns/default-dns-policy/terragrunt.hcl
+++ b/dns/default-dns-policy/terragrunt.hcl
@@ -19,7 +19,7 @@ dependency "vpc" {
 remote_state = include.root.remote_state
 
 terraform {
-  source = "${get_repo_root()}/modules/vpc-dns-policy/"
+  source = "${find_in_parent_folders("modules")}/vpc-dns-policy/"
 }
 
 inputs = {

--- a/dns/google-apis-dns-zones/terragrunt.hcl
+++ b/dns/google-apis-dns-zones/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 include "env" {
-  path = "${get_repo_root()}/_components/restricted-google-apis-dns-zones.hcl"
+  path = "${find_in_parent_folders("_components")}/restricted-google-apis-dns-zones.hcl"
 }
 
 remote_state = include.root.remote_state

--- a/dns/vpc/terragrunt.hcl
+++ b/dns/vpc/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 include "env" {
-  path = "${get_repo_root()}/_components/restricted-vpc.hcl"
+  path = "${find_in_parent_folders("_components")}/restricted-vpc.hcl"
 }
 
 remote_state = include.root.remote_state

--- a/non-production/base/google-apis-dns-zones/terragrunt.hcl
+++ b/non-production/base/google-apis-dns-zones/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 include "env" {
-  path = "${get_repo_root()}/_components/base-google-apis-dns-zones.hcl"
+  path = "${find_in_parent_folders("_components")}/base-google-apis-dns-zones.hcl"
 }
 
 remote_state = include.root.remote_state

--- a/non-production/base/vpc-peering/terragrunt.hcl
+++ b/non-production/base/vpc-peering/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 include "env" {
-  path = "${get_repo_root()}/_components/base-vpc-peering.hcl"
+  path = "${find_in_parent_folders("_components")}/base-vpc-peering.hcl"
 }
 
 remote_state = include.root.remote_state

--- a/non-production/base/vpc/terragrunt.hcl
+++ b/non-production/base/vpc/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 include "base" {
-  path = "${get_repo_root()}/_components/base-vpc.hcl"
+  path = "${find_in_parent_folders("_components")}/base-vpc.hcl"
 }
 
 remote_state = include.root.remote_state

--- a/non-production/default-dns-policy/terragrunt.hcl
+++ b/non-production/default-dns-policy/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 include "env" {
-  path = "${get_repo_root()}/_components/default-dns-policy.hcl"
+  path = "${find_in_parent_folders("_components")}/default-dns-policy.hcl"
 }
 
 remote_state = include.root.remote_state

--- a/non-production/restricted/google-apis-dns-zones/terragrunt.hcl
+++ b/non-production/restricted/google-apis-dns-zones/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 include "env" {
-  path = "${get_repo_root()}/_components/restricted-google-apis-dns-zones.hcl"
+  path = "${find_in_parent_folders("_components")}/restricted-google-apis-dns-zones.hcl"
 }
 
 remote_state = include.root.remote_state

--- a/non-production/restricted/vpc-peering/terragrunt.hcl
+++ b/non-production/restricted/vpc-peering/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 include "env" {
-  path = "${get_repo_root()}/_components/restricted-vpc-peering.hcl"
+  path = "${find_in_parent_folders("_components")}/restricted-vpc-peering.hcl"
 }
 
 remote_state = include.root.remote_state

--- a/non-production/restricted/vpc/terragrunt.hcl
+++ b/non-production/restricted/vpc/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 include "env" {
-  path = "${get_repo_root()}/_components/restricted-vpc.hcl"
+  path = "${find_in_parent_folders("_components")}/restricted-vpc.hcl"
 }
 
 remote_state = include.root.remote_state

--- a/production/base/google-apis-dns-zones/terragrunt.hcl
+++ b/production/base/google-apis-dns-zones/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 include "env" {
-  path = "${get_repo_root()}/_components/base-google-apis-dns-zones.hcl"
+  path = "${find_in_parent_folders("_components")}/base-google-apis-dns-zones.hcl"
 }
 
 remote_state = include.root.remote_state

--- a/production/base/vpc-peering/terragrunt.hcl
+++ b/production/base/vpc-peering/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 include "env" {
-  path = "${get_repo_root()}/_components/base-vpc-peering.hcl"
+  path = "${find_in_parent_folders("_components")}/base-vpc-peering.hcl"
 }
 
 remote_state = include.root.remote_state

--- a/production/base/vpc/terragrunt.hcl
+++ b/production/base/vpc/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 include "base" {
-  path = "${get_repo_root()}/_components/base-vpc.hcl"
+  path = "${find_in_parent_folders("_components")}/base-vpc.hcl"
 }
 
 remote_state = include.root.remote_state

--- a/production/default-dns-policy/terragrunt.hcl
+++ b/production/default-dns-policy/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 include "env" {
-  path = "${get_repo_root()}/_components/default-dns-policy.hcl"
+  path = "${find_in_parent_folders("_components")}/default-dns-policy.hcl"
 }
 
 remote_state = include.root.remote_state
@@ -14,7 +14,7 @@ locals {
 }
 
 terraform {
-  source = "${get_repo_root()}/modules/vpc-dns-policy/"
+  source = "${find_in_parent_folders("modules")}/vpc-dns-policy/"
 }
 
 inputs = {

--- a/production/restricted/google-apis-dns-zones/terragrunt.hcl
+++ b/production/restricted/google-apis-dns-zones/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 include "env" {
-  path = "${get_repo_root()}/_components/restricted-google-apis-dns-zones.hcl"
+  path = "${find_in_parent_folders("_components")}/restricted-google-apis-dns-zones.hcl"
 }
 
 remote_state = include.root.remote_state

--- a/production/restricted/vpc-peering/terragrunt.hcl
+++ b/production/restricted/vpc-peering/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 include "env" {
-  path = "${get_repo_root()}/_components/restricted-vpc-peering.hcl"
+  path = "${find_in_parent_folders("_components")}/restricted-vpc-peering.hcl"
 }
 
 remote_state = include.root.remote_state

--- a/production/restricted/vpc/terragrunt.hcl
+++ b/production/restricted/vpc/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 include "env" {
-  path = "${get_repo_root()}/_components/restricted-vpc.hcl"
+  path = "${find_in_parent_folders("_components")}/restricted-vpc.hcl"
 }
 
 remote_state = include.root.remote_state

--- a/shared/base/google-apis-dns-zones/terragrunt.hcl
+++ b/shared/base/google-apis-dns-zones/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 include "env" {
-  path = "${get_repo_root()}/_components/base-google-apis-dns-zones.hcl"
+  path = "${find_in_parent_folders("_components")}/base-google-apis-dns-zones.hcl"
 }
 
 remote_state = include.root.remote_state

--- a/shared/base/vpc/terragrunt.hcl
+++ b/shared/base/vpc/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 include "env" {
-  path = "${get_repo_root()}/_components/base-vpc.hcl"
+  path = "${find_in_parent_folders("_components")}/base-vpc.hcl"
 }
 
 remote_state = include.root.remote_state

--- a/shared/default-dns-policy/terragrunt.hcl
+++ b/shared/default-dns-policy/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 include "env" {
-  path = "${get_repo_root()}/_components/default-dns-policy.hcl"
+  path = "${find_in_parent_folders("_components")}/default-dns-policy.hcl"
 }
 
 remote_state = include.root.remote_state

--- a/shared/restricted/google-apis-dns-zones/terragrunt.hcl
+++ b/shared/restricted/google-apis-dns-zones/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 include "env" {
-  path = "${get_repo_root()}/_components/restricted-google-apis-dns-zones.hcl"
+  path = "${find_in_parent_folders("_components")}/restricted-google-apis-dns-zones.hcl"
 }
 
 remote_state = include.root.remote_state

--- a/shared/restricted/vpc/terragrunt.hcl
+++ b/shared/restricted/vpc/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 include "env" {
-  path = "${get_repo_root()}/_components/restricted-vpc.hcl"
+  path = "${find_in_parent_folders("_components")}/restricted-vpc.hcl"
 }
 
 remote_state = include.root.remote_state

--- a/terragrunt.hcl.example
+++ b/terragrunt.hcl.example
@@ -31,9 +31,8 @@ inputs = {
 # Defines the base configuration to store Terraform remote state in GCS buckets
 remote_state {
   backend      = "gcs"
-  disable_init = true
   generate = {
-    path      = "backend.tf"
+    path      = "_backend.tf"
     if_exists = "overwrite_terragrunt"
   }
   config = {
@@ -45,7 +44,7 @@ remote_state {
 # Defines the common generate pattern for Google provider.
 # NOTE: Google provider doesn't require explicit configuration so the default is an empty configuration.
 generate "provider" {
-  path      = "provider.tf"
+  path      = "_providers.tf"
   if_exists = "overwrite_terragrunt"
   contents  = <<-EOC
     provider "google" {}


### PR DESCRIPTION
This is the first step to support integration of this repo as a either a submodule, a subtree, or as a snapshot copied to a target.

The functional code is largely unchanged, but dependencies and includes have been updated to use `find_in_parent_folders` in preference to `get_repo_root`.

> NOTE: PR will remain open until a few test repos have included and tested this approach as `git submodule`, etc.